### PR TITLE
Warn Image Failed

### DIFF
--- a/src/com/notcomingsoon/getfics/GFLogger.java
+++ b/src/com/notcomingsoon/getfics/GFLogger.java
@@ -37,7 +37,7 @@ public class GFLogger extends java.util.logging.Logger {
 				fh.setLevel(Level.ALL);
 				fh.setFormatter(new SimpleFormatter());
 				logger.addHandler(fh);
-				logger.setLevel(Level.ALL);
+				logger.setLevel(Level.WARNING);
 			} catch (SecurityException e) {
 				e.printStackTrace();
 			} catch (IOException e) {
@@ -47,5 +47,6 @@ public class GFLogger extends java.util.logging.Logger {
 		}
 		return logger;
 	}
+	
 
 }

--- a/src/com/notcomingsoon/getfics/Main.java
+++ b/src/com/notcomingsoon/getfics/Main.java
@@ -82,12 +82,14 @@ public class Main {
 			while (ficIter.hasNext())
 			{
 				String ficURL = (String) ficIter.next();
+				logger.warning("Starting: " + ficURL);
 				Story story = Site.getStory(ficURL);
 				
 				if (story != null && mobigenPath != null){
 					ProjectFile projectFile = new ProjectFile(story);
 					buildMobi(projectFile, story);
 				}
+				logger.warning("Done: " + ficURL);
 			}
 		} catch (Exception e){				
 			System.out.print(e);

--- a/src/com/notcomingsoon/getfics/sites/Site.java
+++ b/src/com/notcomingsoon/getfics/sites/Site.java
@@ -14,6 +14,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
 
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
@@ -235,7 +236,7 @@ public abstract class Site {
 
 	private void getImages(Document story, Story loc) throws IOException {
 		logger.entering(this.getClass().getCanonicalName(), "getImages(Document story, Story loc)");
-		// TODO Auto-generated method stub
+	
 		Elements images = story.getElementsByTag(HTMLConstants.IMG_TAG);
 		 
 		logger.info("images.size = " + images.size());
@@ -247,7 +248,7 @@ public abstract class Site {
 			}
 			int lastPeriod = src.lastIndexOf(PERIOD);
 			String type = src.substring(lastPeriod+1);
-			Iterator ri = ImageIO.getImageReadersBySuffix(type);
+			Iterator<ImageReader> ri = ImageIO.getImageReadersBySuffix(type);
 			if (!ri.hasNext()){
 				type = JPEG;
 			}
@@ -258,7 +259,6 @@ public abstract class Site {
 				if (null == pic) {
 					image.remove();
 				} else {
-					// String filename = source.getFile();
 					try {
 						File outputFile = new File(loc.getOutputDir(), PIC + i
 								+ PERIOD + type);
@@ -270,7 +270,13 @@ public abstract class Site {
 					}
 				}
 			} catch (Exception e) {
-				image.remove();
+				String name = image.attr(HTMLConstants.SRC_ATTR);
+				int idx = name.lastIndexOf(SLASH) + 1;
+				name = name.substring(idx);
+				image.attr(HTMLConstants.SRC_ATTR, name);
+				logger.warning(loc.toString() + " had at least one picture failure.");
+				logger.warning("Target location: " + loc.getOutputDir());
+				logger.log(Level.WARNING, "Failure: " + src, e );
 			}
 		}
 		


### PR DESCRIPTION
When image download fails warn user and set html for manual download, keeping the image name the same and blanking the path.