### PR TITLE
Added Timestamp to filenames

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,1 @@
 /com/
-/TestImageDownloader

--- a/src/com/notcomingsoon/getfics/Chapter.java
+++ b/src/com/notcomingsoon/getfics/Chapter.java
@@ -31,8 +31,6 @@ public class Chapter {
 	
 	private static Logger logger = GFLogger.getLogger();
 	
-	public static final String CONTENTS = "contents" + HTMLConstants.HTML_EXTENSION;	
-	
 	public static final String CHAPTER = "Chapter";
 	public static final String TOC = "Table of Contents";
 	private static final int ONE_SHOT = 1;
@@ -83,7 +81,7 @@ public class Chapter {
 		
 		if (chapterList.size() > ONE_SHOT){
 			File dir = story.getOutputDir();
-			File f = new File(dir, CONTENTS);
+			File f = new File(dir, story.getContentsFileName());
 	
 			logger.info("f: " + f.toString());	
 			

--- a/src/com/notcomingsoon/getfics/Story.java
+++ b/src/com/notcomingsoon/getfics/Story.java
@@ -2,6 +2,8 @@ package com.notcomingsoon.getfics;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.logging.Logger;
 
 
@@ -20,6 +22,9 @@ public class Story {
 	
 	String origTitle;
 	
+	/* Only populate if previous version of story exists. */
+	Calendar now;
+	
 	File outputDir;
 	
 	private static final String OUTPUT_DIRECTORY = GFProperties.getPropertyValue(GFProperties.OUTPUT_DIRECTORY_KEY);
@@ -29,6 +34,10 @@ public class Story {
 	private boolean isOneShot = false;
 
 	private Charset charset;
+
+	private static final String CONTENTS = "contents";
+	
+	private static final SimpleDateFormat sdf = new SimpleDateFormat("_yyyyMMddHHmmss");
 	
 
 	public String getFileAuthor() {
@@ -96,6 +105,11 @@ public class Story {
 
 		File dir = GFFileUtils.createDirectory(this.getFileAuthor(), this.getFileTitle(), OUTPUT_DIRECTORY);
 		setOutputDir(dir);
+		File f = new File(dir, toString() + HTMLConstants.HTML_EXTENSION);
+		if (f.exists()) {
+			setNow(Calendar.getInstance());
+		}
+
 		
 		logger.exiting("com.notcomingsoon.getfics.Story", "Story(String author, String title)");
 	}
@@ -103,7 +117,7 @@ public class Story {
 	@Override
 	public String toString()
 	{
-		return fileAuthor + "-" + fileTitle;
+		return fileAuthor + "-" + fileTitle + getTimestamp();
 	}
 
 
@@ -124,5 +138,25 @@ public class Story {
 		return charset;
 	}
 
+	public Calendar getNow() {
+		return now;
+	}
 	
+	/** May be empty string. */
+	public String getTimestamp() {
+		String ts = "";
+		if (null != now) {
+			ts = sdf.format(now.getTime());
+		}
+		return ts;
+	}
+
+	/** Only populate if previous version of story exists. */
+	private void setNow(Calendar now) {
+		this.now = now;
+	}
+
+	public String getContentsFileName() {
+		return CONTENTS + getTimestamp() + HTMLConstants.HTML_EXTENSION;
+	}
 }

--- a/src/com/notcomingsoon/getfics/mobi/ProjectFile.java
+++ b/src/com/notcomingsoon/getfics/mobi/ProjectFile.java
@@ -163,7 +163,7 @@ public class ProjectFile {
 			Element ref = project.createElement(REFERENCE_TAG);
 			ref.setAttribute(TYPE_ATTR, TYPE_ATTR_VALUE);
 			ref.setAttribute(REF_TITLE_ATTR, REF_TITLE_ATTR_VALUE);
-			ref.setAttribute(HREF_ATTR, encodeFilename(Chapter.CONTENTS));
+			ref.setAttribute(HREF_ATTR, encodeFilename(story.getContentsFileName()));
 			
 			guide.appendChild(ref);
 		}
@@ -191,7 +191,7 @@ public class ProjectFile {
 			item.setAttribute(ID_ATTR, itemID);
 			itemref.setAttribute(IDREF_ATTR, itemID);
 			item.setAttribute(MEDIA_TYPE_ATTR, MEDIA_TYPE_ATTR_VALUE);
-			String contents = encodeFilename(Chapter.CONTENTS);
+			String contents = encodeFilename(story.getContentsFileName());
 			item.setAttribute(HREF_ATTR, contents);
 			item.setAttribute("properties", "nav");
 			


### PR DESCRIPTION
If previous version of story exists, do not overwrite. THis is done because sometimes I have made edits. Also, sometimes authors claim to have rewritten stuff and it would be interesting to see how much has changed.

This is implemented by adding a timestamp to the filenames if a previous version exists.. This means there could be many versions but, hopefully, on seeing the timestamp, I would investigate why there are multiple copies and delete the un-needed ones.